### PR TITLE
Moole Tag API Fix usage of deprecated function in reviewattempt.php

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -772,8 +772,8 @@ class mod_adaptivequiz_renderer extends plugin_renderer_base {
             $questattempt = $quba->get_question_attempt($slot);
             // Get question definition object.
             $questdef = $questattempt->get_question();
-            // Retrieve the tags associated with this question.
-            $qtags = tag_get_tags_array('question', $questdef->id);
+            // Retrieve the tags associated with this question.            
+            $qtags = core_tag_tag::get_item_tags_array('', 'question', $questdef->id, 0);
 
             $label = html_writer::tag('label', get_string('attemptquestion_level', 'adaptivequiz'));
             $output .= html_writer::tag('div', $label.': '.format_string(adaptivequiz_get_difficulty_from_tags($qtags)));
@@ -932,8 +932,9 @@ class mod_adaptivequiz_renderer extends plugin_renderer_base {
         $sumcorrect = 0;
         $sumincorrect = 0;
         foreach ($quba->get_slots() as $slot) {
-            $question = $quba->get_question($slot);
-            $tags = tag_get_tags_array('question', $question->id);
+            $question = $quba->get_question($slot);            
+            $tags = core_tag_tag::get_item_tags_array('', 'question', $question->id, 0);            
+            
             $qdifficulty = adaptivequiz_get_difficulty_from_tags($tags);
             $qdifficultylogits = catalgo::convert_linear_to_logit($qdifficulty, $adaptivequiz->lowestlevel,
                 $adaptivequiz->highestlevel);
@@ -993,7 +994,7 @@ class mod_adaptivequiz_renderer extends plugin_renderer_base {
 
         foreach ($quba->get_slots() as $i => $slot) {
             $question = $quba->get_question($slot);
-            $tags = tag_get_tags_array('question', $question->id);
+            $tags = core_tag_tag::get_item_tags_array('', 'question', $question->id, 0);            
             $qdifficulty = adaptivequiz_get_difficulty_from_tags($tags);
             $correct = ($quba->get_question_mark($slot) > 0);
 

--- a/tests/adaptiveattempt_test.php
+++ b/tests/adaptiveattempt_test.php
@@ -345,7 +345,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockstate = $this->getMock('question_state_gradedright', array(), array(), '', false);
+        $mockstate = $this->createMock('question_state_gradedright', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_state')
@@ -371,7 +371,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockstate = $this->getMock('question_state_gradedwrong', array(), array(), '', false);
+        $mockstate = $this->createMock('question_state_gradedwrong', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_state')
@@ -397,7 +397,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockstate = $this->getMock('question_state_gradedpartial', array(), array(), '', false);
+        $mockstate = $this->createMock('question_state_gradedpartial', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_state')
@@ -423,7 +423,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockstate = $this->getMock('question_state_gaveup', array(), array(), '', false);
+        $mockstate = $this->createMock('question_state_gaveup', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_state')
@@ -449,7 +449,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockstate = $this->getMock('question_state_todo', array(), array(), '', false);
+        $mockstate = $this->createMock('question_state_todo', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_state')
@@ -503,7 +503,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test quba returning a mark of 1.0
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockquba->expects($this->once())
             ->method('get_question_mark')
@@ -523,7 +523,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test quba returning a non float value
-        $mockqubatwo = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockqubatwo = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockqubatwo->expects($this->once())
             ->method('get_question_mark')
@@ -543,7 +543,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test quba returning null
-        $mockqubathree = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockqubathree = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockqubathree->expects($this->once())
                 ->method('get_question_mark')
@@ -563,7 +563,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         $functions = array('get_attempt', 'max_questions_answered', 'level_in_bounds');
-        $mockattempt = $this->getMock('adaptiveattempt', $functions, array(), '', false);
+        $mockattempt = $this->createMock('adaptiveattempt', $functions, array(), '', false);
 
         $mockattempt->expects($this->once())
             ->method('get_attempt')
@@ -577,7 +577,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->method('level_in_bounds')
             ->will($this->returnValue(true));
 
-        $this->assertFalse($mockattempt->start_attempt());
+        $this->assertFalse($mockattempt->start_attempt(0));
     }
 
     /**
@@ -589,7 +589,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
         $dummy->highestlevel = 100;
 
         $functions = array('get_attempt', 'max_questions_answered', 'initialize_quba', 'find_last_quest_used_by_attempt', 'level_in_bounds');
-        $mockattemptthree = $this->getMock('adaptiveattempt', $functions, array($dummy, 1), '', true);
+        $mockattemptthree = $this->createMock('adaptiveattempt', $functions, array($dummy, 1), '', true);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 1;
@@ -613,7 +613,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->method('find_last_quest_used_by_attempt')
             ->will($this->returnValue(0));
 
-        $this->assertFalse($mockattemptthree->start_attempt());
+        $this->assertFalse($mockattemptthree->start_attempt(0));
     }
 
     /**

--- a/tests/adaptiveattempt_test.php
+++ b/tests/adaptiveattempt_test.php
@@ -577,7 +577,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->method('level_in_bounds')
             ->will($this->returnValue(true));
 
-        $this->assertFalse($mockattempt->start_attempt(0));
+        $this->assertFalse($mockattempt->start_attempt());
     }
 
     /**
@@ -613,7 +613,7 @@ class mod_adaptivequiz_adaptiveattempt_testcase extends advanced_testcase {
             ->method('find_last_quest_used_by_attempt')
             ->will($this->returnValue(0));
 
-        $this->assertFalse($mockattemptthree->start_attempt(0));
+        $this->assertFalse($mockattemptthree->start_attempt());
     }
 
     /**

--- a/tests/catalgo_test.php
+++ b/tests/catalgo_test.php
@@ -59,7 +59,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_init_catalgo_negative_int_throw_except() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, -1);
     }
@@ -71,7 +71,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_init_catalgo_no_level_throw_except() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, 1, true);
     }
@@ -83,7 +83,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
         $this->setup_test_data_xml();
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, 1, true, 1);
 
@@ -108,7 +108,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
         $this->setup_test_data_xml();
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, 1, true, 1);
 
@@ -121,7 +121,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_quest_was_marked_correct_no_submit_prev_quest_fail() {
         $this->resetAfterTest(true);
 
-        $mockcatalgo = $this->getMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
 
         $mockcatalgo->expects($this->once())
                 ->method('find_last_quest_used_by_attempt')
@@ -146,7 +146,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_quest_was_marked_correct_zero_slot_number_fail() {
         $this->resetAfterTest(true);
 
-        $mockcatalgo = $this->getMock('catalgo', array('find_last_quest_used_by_attempt', 'get_question_mark'), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('find_last_quest_used_by_attempt', 'get_question_mark'), array(), '', false);
 
         $mockcatalgo->expects($this->once())
                 ->method('find_last_quest_used_by_attempt')
@@ -166,8 +166,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_quest_was_marked_correct_mark_is_null_fail() {
         $this->resetAfterTest(true);
 
-        $mockcatalgo = $this->getMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockcatalgo->expects($this->once())
                 ->method('find_last_quest_used_by_attempt')
@@ -194,8 +194,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_quest_was_marked_correct_mark_zero() {
         $this->resetAfterTest(true);
 
-        $mockcatalgo = $this->getMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockcatalgo->expects($this->once())
                 ->method('find_last_quest_used_by_attempt')
@@ -222,7 +222,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_quest_was_marked_correct_mark_non_zero() {
         $this->resetAfterTest(true);
 
-        $mockcatalgo = $this->getMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('find_last_quest_used_by_attempt', 'was_answer_submitted_to_question', 'get_question_mark'), array(), '', false);
         $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockcatalgo->expects($this->once())
@@ -251,7 +251,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
         $this->setup_test_data_xml();
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, 1, true, 1);
 
@@ -267,7 +267,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
         $this->setup_test_data_xml();
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $algo = new catalgo($mockquba, 1, true, 1);
 
@@ -281,7 +281,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_compute_next_difficulty_zero_min_one_hundred_max() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $catalgo = new catalgo($mockquba, 1, true, 1);
         $dummy = new stdClass();
@@ -313,7 +313,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_compute_next_difficulty_one_min_ten_max_compute_infinity() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $catalgo = new catalgo($mockquba, 1, true, 1);
         $dummy = new stdClass();
@@ -335,7 +335,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test quba returning a mark of 1.0
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_question_mark')
@@ -346,7 +346,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->assertEquals(1.0, $result);
 
         // Test quba returning a non float value
-        $mockqubatwo = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockqubatwo = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $mockqubatwo->expects($this->once())
                 ->method('get_question_mark')
@@ -364,7 +364,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test use case where user got all 5 question correct
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->exactly(5))
                 ->method('get_question_mark')
@@ -386,7 +386,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test use case where user got all 5 question incorrect
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->exactly(5))
                 ->method('get_question_mark')
@@ -407,7 +407,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_compute_right_answers_null_return_from_get_question_mark() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_question_mark')
@@ -429,7 +429,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test use case where user got all 5 question incorrect
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->exactly(5))
                 ->method('get_question_mark')
@@ -451,7 +451,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Test use case where user got all 5 question correct
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->exactly(5))
                 ->method('get_question_mark')
@@ -472,7 +472,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_compute_wrong_answers_null_return_from_get_question_mark() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_mark'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_question_mark')
@@ -493,7 +493,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_estimate_measure() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         // Test an attempt with the following details:
         // sum of difficulty - 20, number of questions attempted - 10, number of correct answers - 7, number of incorrect answers - 3
@@ -508,7 +508,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_estimate_standard_error() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         // Test an attempt with the following details;
         // sum of questions attempted - 10, number of correct answers - 7, number of incorrect answers - 3
@@ -526,7 +526,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'estimate_measure', 'estimate_standard_error', 'retrieve_standard_error', 'standard_error_within_parameters');
-        $mockcatalgo = $this->getMock('catalgo', $functions, array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', $functions, array(), '', false);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 10;
@@ -575,7 +575,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty',
                 'compute_right_answers', 'compute_wrong_answers', 'retrieve_standard_error');
-        $mockcatalgo = $this->getMock('catalgo', $functions, array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', $functions, array(), '', false);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 10;
@@ -619,7 +619,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty',
                 'compute_right_answers', 'compute_wrong_answers', 'retrieve_standard_error');
-        $mockcatalgo = $this->getMock('catalgo', $functions, array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', $functions, array(), '', false);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 10;
@@ -663,7 +663,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'estimate_measure', 'estimate_standard_error', 'retrieve_standard_error', 'standard_error_within_parameters');
-        $mockcatalgo = $this->getMock('catalgo', $functions, array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', $functions, array(), '', false);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 0; // Questions attempted is set to zero
@@ -715,7 +715,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'estimate_measure', 'estimate_standard_error', 'retrieve_standard_error', 'standard_error_within_parameters');
-        $mockcatalgo = $this->getMock('catalgo', $functions, array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', $functions, array(), '', false);
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 3; // Sum of question attempted
@@ -765,13 +765,13 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_perform_calculation_steps_nostop_correct_answer() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'estimate_measure', 'estimate_standard_error', 'retrieve_standard_error', 'standard_error_within_parameters');
         // Minimum stopping criteria has not been met
-        $mockcatalgo = $this->getMock('catalgo', $functions, array($mockquba, 1, false, 50));
+        $mockcatalgo = $this->createMock('catalgo', $functions, array($mockquba, 1, false, 50));
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 1;
@@ -819,13 +819,13 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_perform_calculation_steps_nostop_incorrect_answer() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'estimate_measure', 'estimate_standard_error', 'retrieve_standard_error', 'standard_error_within_parameters');
         // Minimum stopping criteria has not been met
-        $mockcatalgo = $this->getMock('catalgo', $functions, array($mockquba, 1, false, 50));
+        $mockcatalgo = $this->createMock('catalgo', $functions, array($mockquba, 1, false, 50));
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 1;
@@ -873,13 +873,13 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_perform_calculation_steps_stop_no_fail() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $functions = array(
                 'retrieve_attempt_record', 'question_was_marked_correct', 'compute_next_difficulty', 'compute_right_answers', 'compute_wrong_answers',
                 'retrieve_standard_error', 'standard_error_within_parameters');
         // Minimum stopping criteria has been met
-        $mockcatalgo = $this->getMock('catalgo', $functions, array($mockquba, 1, true, 50));
+        $mockcatalgo = $this->createMock('catalgo', $functions, array($mockquba, 1, true, 50));
 
         $dummyattempt = new stdClass();
         $dummyattempt->questionsattempted = 2;
@@ -930,7 +930,7 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
     public function test_standard_error_within_parameters_return_true_then_false() {
         $this->resetAfterTest(true);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
 
         $catalgo = new catalgo($mockquba, 1, true, 1);
         $result = $catalgo->standard_error_within_parameters(0.02, 0.1);
@@ -951,8 +951,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 1;
         $dummy->highestlevel = 20;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->never())
                 ->method('return_current_diff_level');
@@ -971,8 +971,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 1;
         $dummy->highestlevel = 20;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->never())
                 ->method('return_current_diff_level');
@@ -989,8 +989,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
 
         $dummy = new stdClass();
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->never())
                 ->method('return_current_diff_level');
@@ -1008,8 +1008,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy = new stdClass();
         $dummy->highestlevel = 20;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->never())
                 ->method('return_current_diff_level');
@@ -1027,8 +1027,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy = new stdClass();
         $dummy->lowestlevel = 20;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->never())
                 ->method('return_current_diff_level');
@@ -1046,8 +1046,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 20;
         $dummy->highestlevel = 21;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array(), array(), '', false);
-        $mockcatalgo = $this->getMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array(), array(), '', false);
+        $mockcatalgo = $this->createMock('catalgo', array('return_current_diff_level'), array($mockquba, 1, true, 50));
 
         $mockcatalgo->expects($this->once())
                 ->method('return_current_diff_level')
@@ -1068,8 +1068,8 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 20;
         $dummy->highestlevel = 21;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
-        $mockcatalgo = $this->getMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
+        $mockcatalgo = $this->createMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
 
         $mockquba->expects($this->once())
                 ->method('get_slots')
@@ -1098,9 +1098,9 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 20;
         $dummy->highestlevel = 21;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
-        $mockcatalgo = $this->getMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
-        $mockstate = $this->getMock('question_state_gaveup', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
+        $mockcatalgo = $this->createMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
+        $mockstate = $this->createMock('question_state_gaveup', array(), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_slots')
@@ -1134,9 +1134,9 @@ class mod_adaptivequiz_catalgo_testcase extends advanced_testcase {
         $dummy->lowestlevel = 20;
         $dummy->highestlevel = 21;
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
-        $mockcatalgo = $this->getMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
-        $mockstate = $this->getMock('question_state_todo', array(), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'get_question_state'), array(), '', false);
+        $mockcatalgo = $this->createMock('mod_adaptivequiz_mock_catalgo', array('get_question_mark', 'compute_next_difficulty'), array($mockquba, 1, true, 50));
+        $mockstate = $this->createMock('question_state_todo', array(), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_slots')

--- a/tests/fetchquestion_test.php
+++ b/tests/fetchquestion_test.php
@@ -135,7 +135,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->setup_test_data_xml();
         $this->setup_generator_data();
 
-        $attempt = $this->getMock('fetchquestion', array('retrieve_question_categories'), array($this->activityinstance, 1, 1, 100));
+        $attempt = $this->createMock('fetchquestion', array('retrieve_question_categories'), array($this->activityinstance, 1, 1, 100));
 
         $attempt->expects($this->exactly(2))
                 ->method('retrieve_question_categories')
@@ -158,7 +158,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->setup_test_data_xml();
         $this->setup_generator_data();
 
-        $mockclass = $this->getMock(
+        $mockclass = $this->createMock(
                 'fetchquestion',
                 array('retrieve_question_categories'),
                 array($this->activityinstance, 1, 1, 100)
@@ -187,7 +187,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->setup_test_data_xml();
         $this->setup_generator_data();
 
-        $mockclass = $this->getMock('fetchquestion', array('retrieve_question_categories'), array($this->activityinstance, 1, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', array('retrieve_question_categories'), array($this->activityinstance, 1, 1, 100));
 
         $mockclass->expects($this->once())
                 ->method('retrieve_question_categories')
@@ -269,7 +269,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
 
         $mockclass->expects($this->once())
                 ->method('initalize_tags_with_quest_count')
@@ -294,7 +294,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
 
         $tagquestsum = array(5 => 2);
         $mockclass->expects($this->once())
@@ -325,7 +325,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
 
         $tagquestsum = array(5 => 0, 6 => 1);
         $mockclass->expects($this->once())
@@ -356,7 +356,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
 
         $tagquestsum = array(1 => 0, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0, 7 => 0, 8 => 0, 9 => 0, 10 => 2);
         $mockclass->expects($this->once())
@@ -387,7 +387,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 5, 1, 100));
 
         $tagquestsum = array(1 => 1, 2 => 0, 3 => 0, 4 => 0, 5 => 0, 6 => 0, 7 => 0, 8 => 0, 9 => 0, 10 => 0);
         $mockclass->expects($this->once())
@@ -418,7 +418,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $dummyclass = new stdClass();
 
         $functions = array('initalize_tags_with_quest_count', 'retrieve_tag', 'find_questions_with_tags');
-        $mockclass = $this->getMock('fetchquestion', $functions, array($dummyclass, 50, 49, 51));
+        $mockclass = $this->createMock('fetchquestion', $functions, array($dummyclass, 50, 49, 51));
 
         $tagquestsum = array(48 => 1, 52 => 1);
         $mockclass->expects($this->once())
@@ -521,7 +521,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         $dummyclass = new stdClass();
-        $mockclass = $this->getMock(
+        $mockclass = $this->createMock(
                 'fetchquestion',
                 array('retrieve_question_categories', 'retrieve_all_tag_ids', 'retrieve_tags_with_question_count'),
                 array($dummyclass, 1, 1, 100)
@@ -556,7 +556,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         $dummyclass = new stdClass();
-        $mockclass = $this->getMock(
+        $mockclass = $this->createMock(
                 'fetchquestion',
                 array('retrieve_question_categories', 'retrieve_all_tag_ids', 'retrieve_tags_with_question_count'),
                 array($dummyclass, 1, 1, 100)
@@ -583,7 +583,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->resetAfterTest(true);
 
         $dummyclass = new stdClass();
-        $mockclass = $this->getMock(
+        $mockclass = $this->createMock(
                 'fetchquestion',
                 array('retrieve_question_categories', 'retrieve_all_tag_ids', 'retrieve_tags_with_question_count'),
                 array($dummyclass, 1, 1, 100)
@@ -649,7 +649,7 @@ class mod_adaptivequiz_fetchquestion_testcase extends advanced_testcase {
         $this->setup_test_data_xml();
         $this->setup_generator_data();
 
-        $mockclass = $this->getMock('fetchquestion', array('retrieve_question_categories'), array(new stdClass(), 1, 1, 100));
+        $mockclass = $this->createMock('fetchquestion', array('retrieve_question_categories'), array(new stdClass(), 1, 1, 100));
 
         $mockclass->expects($this->once())
                 ->method('retrieve_question_categories')

--- a/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
+++ b/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
@@ -280,7 +280,6 @@
         <column>maximumquestions</column>
         <column>standarderror</column>
         <column>startinglevel</column>
-        <column>preferredbehaviour</column>
         <row>
             <value>330</value>
             <value>1</value>
@@ -293,7 +292,6 @@
             <value>20</value>
             <value>1.0</value>
             <value>50</value>
-            <value>immediatefeedback</value>
         </row>
  <!--       <row>
             <value>221</value>

--- a/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
+++ b/tests/fixtures/mod_adaptivequiz_adaptiveattempt.xml
@@ -216,10 +216,11 @@
             <value>1</value>
             <value>2</value>
         </row>
-    </table>
+    </table>   
     <table name="tag">
         <column>id</column>
         <column>userid</column>
+        <column>tagcollid</column>
         <column>name</column>
         <column>rawname</column>
         <column>tagtype</column>
@@ -227,6 +228,7 @@
         <row>
             <value>1</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_5</value>
             <value>adpq_5</value>
             <value>default</value>
@@ -235,6 +237,7 @@
         <row>
             <value>2</value>
             <value>2</value>
+            <value>1</value>
             <value>phpunittag_5</value>
             <value>phpunittag_5</value>
             <value>default</value>
@@ -243,6 +246,7 @@
         <row>
             <value>3</value>
             <value>2</value>
+            <value>1</value>
             <value>phpunittag_888</value>
             <value>phpunittag_888</value>
             <value>default</value>
@@ -276,6 +280,7 @@
         <column>maximumquestions</column>
         <column>standarderror</column>
         <column>startinglevel</column>
+        <column>preferredbehaviour</column>
         <row>
             <value>330</value>
             <value>1</value>
@@ -288,6 +293,7 @@
             <value>20</value>
             <value>1.0</value>
             <value>50</value>
+            <value>immediatefeedback</value>
         </row>
  <!--       <row>
             <value>221</value>

--- a/tests/fixtures/mod_adaptivequiz_findquestion.xml
+++ b/tests/fixtures/mod_adaptivequiz_findquestion.xml
@@ -31,53 +31,62 @@
         <column>name</column>
         <column>contextid</column>
         <column>info</column>
+        <column>stamp</column>
         <row>
             <value>1</value>
             <value>Default for 101</value>
             <value>16</value>
             <value>default question category</value>
+            <value>example.loc+161208110835+ZNzubk</value>
         </row>
         <row>
             <value>2</value>
             <value>Default for Miscellaneous</value>
             <value>3</value>
             <value>default question category</value>
+            <value>example.loc+161208112421+aQXIHP</value>
         </row>
         <row>
             <value>3</value>
             <value>Default for System</value>
             <value>1</value>
             <value>default question category</value>
+            <value>example.loc+161208112421+HX4iPR</value>
         </row>
         <row>
             <value>4</value>
             <value>Test reattempt</value>
             <value>16</value>
             <value>Data test for fetch_question</value>
+            <value>example.loc+161208112853+RAFrV1</value>
         </row>
         <row>
             <value>5</value>
             <value>retrieve_tags_with_question_count</value>
             <value>16</value>
             <value>test_retrieve_tags_with_question_count</value>
+            <value>example.loc+161208112930+1oAcF9</value>
         </row>
         <row>
             <value>6</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category 1</value>
             <value>16</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category</value>
+            <value>example.loc+161208120113+5PvXXH</value>
         </row>
         <row>
             <value>7</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category 2</value>
             <value>16</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category</value>
+            <value>example.loc+170110181010+Ig7DE6</value>
         </row>
         <row>
             <value>8</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category 3</value>
             <value>16</value>
             <value>find_questions_with_tags_with_multiple_quest_in_quest_category</value>
+            <value>example.loc+170110181307+5LFZK2</value>
         </row>
     </table>
     <table name="question">
@@ -263,6 +272,7 @@
     <table name="tag">
         <column>id</column>
         <column>userid</column>
+        <column>tagcollid</column>
         <column>name</column>
         <column>rawname</column>
         <column>tagtype</column>
@@ -270,6 +280,7 @@
         <row>
             <value>1</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_5</value>
             <value>adpq_5</value>
             <value>default</value>
@@ -278,6 +289,7 @@
         <row>
             <value>2</value>
             <value>2</value>
+            <value>1</value>
             <value>phpunittag_5</value>
             <value>phpunittag_5</value>
             <value>default</value>
@@ -286,6 +298,7 @@
         <row>
             <value>3</value>
             <value>2</value>
+            <value>1</value>
             <value>phpunittag_888</value>
             <value>phpunittag_888</value>
             <value>default</value>
@@ -294,6 +307,7 @@
         <row>
             <value>4</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_6</value>
             <value>adpq_6</value>
             <value>default</value>
@@ -302,6 +316,7 @@
         <row>
             <value>5</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_7</value>
             <value>adpq_7</value>
             <value>default</value>
@@ -310,6 +325,7 @@
         <row>
             <value>6</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_8</value>
             <value>adpq_8</value>
             <value>default</value>
@@ -318,6 +334,7 @@
         <row>
             <value>7</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_9</value>
             <value>adpq_9</value>
             <value>default</value>
@@ -326,6 +343,7 @@
         <row>
             <value>8</value>
             <value>2</value>
+            <value>1</value>
             <value>adpq_10</value>
             <value>adpq_10</value>
             <value>default</value>
@@ -334,6 +352,7 @@
         <row>
             <value>22</value>
             <value>2</value>
+            <value>1</value>
             <value>test1_22</value>
             <value>test1_22</value>
             <value>default</value>
@@ -342,6 +361,7 @@
         <row>
             <value>23</value>
             <value>2</value>
+            <value>1</value>
             <value>test1_23</value>
             <value>test1_23</value>
             <value>default</value>
@@ -350,6 +370,7 @@
         <row>
             <value>24</value>
             <value>2</value>
+            <value>1</value>
             <value>test1_24</value>
             <value>test1_24</value>
             <value>default</value>

--- a/tests/renderer_test.php
+++ b/tests/renderer_test.php
@@ -101,7 +101,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('render_question'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('render_question'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('render_question')
@@ -210,7 +210,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('render_question_head_html'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('render_question_head_html'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('render_question_head_html')
@@ -228,7 +228,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_slots')
@@ -246,7 +246,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots'), array(), '', false);
 
         $mockpages = array_keys(array_fill(0, 25, 1));
         $mockquba->expects($this->once())
@@ -274,7 +274,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots'), array(), '', false);
 
         $mockpages = array_keys(array_fill(0, 11, 1));
         $mockquba->expects($this->once())
@@ -299,7 +299,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         $target = 'mod_adaptivequiz';
         $renderer = new mod_adaptivequiz_renderer($dummypage, $target);
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots'), array(), '', false);
 
         $mockpages = array_keys(array_fill(0, 11, 1));
         $mockquba->expects($this->once())
@@ -324,7 +324,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
         global $DB;
         $user = $DB->get_record('user', array('id' => 2));
 
-        $renderer = $this->getMock('mod_adaptivequiz_renderer', array('init_metadata', 'heading'), array(), '', false);
+        $renderer = $this->createMock('mod_adaptivequiz_renderer', array('init_metadata', 'heading'), array(), '', false);
 
         $renderer->expects($this->once())
                 ->method('init_metadata')
@@ -334,7 +334,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
                 ->method('heading')
                 ->will($this->returnValue('phpunit test heading'));
 
-        $mockquestattempt = $this->getMock('question_attempt', array('get_question'), array(), '', false);
+        $mockquestattempt = $this->createMock('question_attempt', array('get_question'), array(), '', false);
 
         $dummy = new stdClass();
         $dummy->id = 1;
@@ -342,7 +342,7 @@ class mod_adaptivequiz_renderer_testcase extends advanced_testcase {
                 ->method('get_question')
                 ->will($this->returnValue($dummy));
 
-        $mockquba = $this->getMock('question_usage_by_activity', array('get_slots', 'render_question', 'get_question_attempt'), array(), '', false);
+        $mockquba = $this->createMock('question_usage_by_activity', array('get_slots', 'render_question', 'get_question_attempt'), array(), '', false);
 
         $mockquba->expects($this->once())
                 ->method('get_slots')


### PR DESCRIPTION
I have fixed three deprecated function instances in reviewattempt.php :
"Method tag_get_tags_array() is deprecated and replaced with core_tag_tag::get_item_tags_array()"