### PR TITLE
fix issue #45: SQL error when clicking the 'Start attempt' button with Moodle 3.0.6. Edit the group by statement

### DIFF
--- a/fetchquestion.class.php
+++ b/fetchquestion.class.php
@@ -433,7 +433,7 @@ class fetchquestion {
                            AND ti.tagid $includetags
                            AND q.category $includeqcats
                   GROUP BY t.name
-                  ORDER BY t.id ASC";
+                  ORDER BY t.name ASC";
             $records = $DB->get_records_sql_menu($sql, $params);
             return $records;
         } catch (coding_exception $e) {


### PR DESCRIPTION
This Pull Request fixes issue #45 : this sounds like a `GROUP BY` issue. I just fix the `GROUP BY` clause, this is now running fine.
